### PR TITLE
Elimina mensaje de advertencia en Ubuntu-mate 18-04

### DIFF
--- a/bin/power-commands
+++ b/bin/power-commands
@@ -58,7 +58,7 @@ def test_if_apps():
     if de == 'mate':
         if not is_package_installed('mate-session-manager'):
             packages_not_installed.append('mate-session')
-        if not is_package_installed('mate-screensaver-manager'):
+        if not is_package_installed('mate-screensaver'):
             packages_not_installed.append('mate-screensaver')
     elif de == 'cinnamon':
         if not is_package_installed('cinnamon-session'):


### PR DESCRIPTION
Al apagar Mate mostraba un mensaje de advertencia diciendo que el paquete 'mate-screensaver' no estaba instalado, pese a estarlo y apagar el equipo correctamente.