### PR TITLE
Close session and lock screen support for Plasma using gdbus 

### DIFF
--- a/bin/power-commands
+++ b/bin/power-commands
@@ -183,6 +183,8 @@ boolean:true')
             run('gnome-session-quit --logout --no-prompt')
         elif de == 'cinnamon':
             run('cinnamon-session-quit --logout --no-prompt')
+        elif de == 'kde':
+            run('qdbus org.kde.ksmserver /KSMServer logout 0 3 3')
     elif action == 'lock':
         de = get_desktop_environment()
         if de == 'mate':
@@ -191,6 +193,8 @@ boolean:true')
             run('gnome-screensaver-command --lock')
         elif de == 'cinnamon':
             run('cinnamon-screensaver-command --lock')
+        else:
+            run('gdbus org.freedesktop.ScreenSaver /ScreenSaver Lock')
     elif action == 'screensaver':
         de = get_desktop_environment()
         if de == 'mate':
@@ -199,6 +203,9 @@ boolean:true')
             run('gnome-screensaver-command --activate')
         elif de == 'cinnamon':
             run('cinnamon-screensaver-command --activate')
+        else:
+            run('qdbus org.freedesktop.ScreenSaver /ScreenSaver '
+                'org.freedesktop.ScreenSaver.SetActive True')
 
 
 def messagedialog(title, message):


### PR DESCRIPTION
I have been using powercommands for a long time and Plasmafor about two years. Now I do not remember, but I think before I closed session and lock the screen using Plasma and power-commands (but seeing the code I do not understand, maybe it was in other DE)

I have allowed myself to make some small modifications to work on Plasma using gdbus.

P.S: Tested on KDE neon User Edition 5.15 (Ubuntu 18.04 based)